### PR TITLE
Make source compatible with all supported types in pushsource lib

### DIFF
--- a/docs/push.rst
+++ b/docs/push.rst
@@ -20,7 +20,7 @@ A typical invocation of push would look like this:
                  "default": {"access-1": "secret-1"}}' \
     --aws-access-id access_id \
     --aws-secret-key secret_key \
-    /stage/ami/root
+    staged:/stage/ami/root
 
 All the AMIs in the given source path will be verified for
 provider and product combination in RHSM and then uploaded
@@ -44,7 +44,7 @@ should be used. This updates the metadata on RHSM services.
     --aws-access-id access_id \
     --aws-secret-key secret_key \
     --ship \
-    /stage/ami/root
+    staged:/stage/ami/root
 
 
 Shipping the images to general public i.e. ones that are available
@@ -62,7 +62,7 @@ fee requires using --allow-public-images along with the above options.
     --aws-secret-key secret_key \
     --ship \
     --allow-public-image \
-    /stage/ami/root
+    staged:/stage/ami/root
 
 
 Example: modify retry
@@ -82,4 +82,4 @@ for 4 times after every 30 seconds. These defaults can be modified as:
     --aws-secret-key secret_key \
     --max-retires 2 \
     --retry-wait 10 \
-    /stage/ami/root
+    staged:/stage/ami/root

--- a/pubtools/_ami/tasks/push.py
+++ b/pubtools/_ami/tasks/push.py
@@ -56,7 +56,7 @@ class AmiPush(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
         ami_push_items = []
 
         for source_loc in self.args.source:
-            with Source.get("staged:", url=source_loc) as source:
+            with Source.get(source_loc) as source:
                 for push_item in source:
                     if not isinstance(push_item, AmiPushItem):
                         LOG.warning(
@@ -380,7 +380,9 @@ class AmiPush(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
         group.add_argument(
             "source",
             nargs="+",
-            help="source location of the staged AMIs",
+            help="source location of the staged AMIs with the source type. "
+            "e.g. staged:/path/to/stage/ami or "
+            "errata:https://errata.example.com?errata=RHBA-2020:1234",
             action=SplitAndExtend,
             split_on=",",
         )

--- a/tests/push/test_ami_push.py
+++ b/tests/push/test_ami_push.py
@@ -8,6 +8,7 @@ from mock import patch, MagicMock
 from pubtools._ami.tasks.push import AmiPush, entry_point
 
 AMI_STAGE_ROOT = "/tmp/aws_staged"
+AMI_SOURCE = "staged:%s" % AMI_STAGE_ROOT
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -99,7 +100,7 @@ def test_do_push(command_tester, requests_mocker):
             "secret_key",
             "--ship",
             "--debug",
-            AMI_STAGE_ROOT,
+            AMI_SOURCE,
         ],
     )
 
@@ -121,7 +122,7 @@ def test_no_rhsm_url(command_tester):
     """Raises an error that RHSM url is not provided"""
     command_tester.test(
         lambda: entry_point(AmiPush),
-        ["test-push", "--debug", AMI_STAGE_ROOT],
+        ["test-push", "--debug", AMI_SOURCE],
     )
 
 
@@ -140,7 +141,7 @@ def test_no_aws_credentials(command_tester):
             accounts,
             "--retry-wait",
             "1",
-            AMI_STAGE_ROOT,
+            AMI_SOURCE,
         ],
     )
 
@@ -162,7 +163,7 @@ def test_missing_product(command_tester):
             "--aws-secret-key",
             "secret_key",
             "--debug",
-            AMI_STAGE_ROOT,
+            AMI_SOURCE,
         ],
     )
 
@@ -188,7 +189,7 @@ def test_push_public_image(command_tester):
             "--ship",
             "--allow-public-image",
             "--debug",
-            AMI_STAGE_ROOT,
+            AMI_SOURCE,
         ],
     )
 
@@ -214,7 +215,7 @@ def test_create_region_failure(command_tester, requests_mocker):
             "secret_key",
             "--ship",
             "--debug",
-            AMI_STAGE_ROOT,
+            AMI_SOURCE,
         ],
     )
 
@@ -243,14 +244,14 @@ def test_create_image_failure(command_tester, requests_mocker):
             "secret_key",
             "--ship",
             "--debug",
-            AMI_STAGE_ROOT,
+            AMI_SOURCE,
         ],
     )
 
 
 def test_not_ami_push_item(command_tester, staged_file):
     """Non AMI pushitem is skipped from inclusion in push list"""
-    temp_stage = staged_file
+    temp_stage = "staged:%s" % staged_file
 
     command_tester.test(
         lambda: entry_point(AmiPush),
@@ -306,6 +307,6 @@ def test_aws_publish_failures(command_tester, mock_aws_publish):
             "--ship",
             "--allow-public-image",
             "--debug",
-            AMI_STAGE_ROOT,
+            AMI_SOURCE,
         ],
     )


### PR DESCRIPTION
This patch updates the source arg to be one of the source types
supported by the pushsource library like staged, errata etc.
instead of current support only for staged source type.
It will make the library forward-compatible with other sources
that may be added in future.

fix #4