### PR TITLE
Update tox cov job to generate xml coverage report for codecov-action v2

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.15
+        uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
           verbose: true

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands=pidiff pubtools-ami .
 [testenv:cov]
 usedevelop=true
 commands=
-	pytest --cov-report=html --cov=pubtools {posargs}
+	pytest --cov-report=html --cov-report=xml --cov=pubtools {posargs}
 
 [testenv:docs]
 use_develop=true


### PR DESCRIPTION
Codecov action to upload coverage report is being upgraded to v2.
However, v2 accepts coverage reports in xml format only. Hence,
updating the cov job in tox to generate coverage reports in xml
instead of html.