### PR TITLE
Generate images.json closer to existing format

### DIFF
--- a/pubtools/_ami/tasks/push.py
+++ b/pubtools/_ami/tasks/push.py
@@ -372,10 +372,19 @@ class AmiPush(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
             if isinstance(obj, (datetime.datetime, datetime.date)):
                 return obj.strftime("%Y%m%d")
 
+        mod_result = []
         for result in results:
-            result["push_item"] = attr.asdict(result["push_item"])
+            res_dict = attr.asdict(result["push_item"])
+            # dict can't be modified during iteration.
+            # so iterate over list of keys.
+            for key in list(res_dict):
+                if res_dict[key] is None:
+                    del res_dict[key]
+            res_dict["ami"] = result["image_id"]
+            res_dict["name"] = result["image_name"]
+            mod_result.append(res_dict)
 
-        metadata = json.dumps(results, default=convert, indent=2, sort_keys=True)
+        metadata = json.dumps(mod_result, default=convert, indent=2, sort_keys=True)
         return self.collector.attach_file("images.json", metadata).result()
 
     def add_args(self):


### PR DESCRIPTION
Currently, images.json contains the result from the
upload dumped as-is with all the required info. However,
it differs/loses the existing format/fields/field names.
This patch modifies the result to generate the json similar
to the existing one with the same field names and format.
The new json has some added fields like origin, src, state
etc. from the pushitem apart from the existing ones.