### PR TITLE
Allow empty billing_codes.codes [RHELDST-10593]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.8

--- a/pubtools/_ami/tasks/push.py
+++ b/pubtools/_ami/tasks/push.py
@@ -228,7 +228,7 @@ class AmiPush(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
             "virt_type": push_item.virtualization,
             "root_device_name": push_item.root_device,
             "volume_type": push_item.volume,
-            "billing_products": push_item.billing_codes.codes,
+            "billing_products": push_item.billing_codes.codes or None,
             "accounts": accounts,
             "sriov_net_support": push_item.sriov_net_support,
             "ena_support": push_item.ena_support or False,


### PR DESCRIPTION
We need to push AMI images without billing codes,
let pass None to AWS publish metadata for the
billing_products argument if billing_codes.codes
are empty.