### PR TITLE
Change --snapshot-account-ids parsing [RHELDST-11233]

### DIFF
--- a/pubtools/_ami/tasks/push.py
+++ b/pubtools/_ami/tasks/push.py
@@ -452,10 +452,11 @@ class AmiPush(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
 
         group.add_argument(
             "--snapshot-account-ids",
-            help="List of account ids to give snapshot creation permissions to if a new snapshot "
-            "is created as part of the image push.",
-            action="append",
-            type=str,
+            help="Comma separated list of account ids to give snapshot "
+            "creation permissions to if a new snapshot is created as "
+            "part of the image push.",
+            action=SplitAndExtend,
+            split_on=",",
             default=["679593333241", "684062674729", "425685993791", "582767206473"],
         )
 

--- a/tests/logs/push/test_ami_push/test_do_push.txt
+++ b/tests/logs/push/test_ami_push/test_do_push.txt
@@ -4,7 +4,7 @@
 [   DEBUG] 1 Products(AWS provider) in rhsm: RHEL_HOURLY(awstest)
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-r"], "arch": "x86_64", "billing_products": ["code-0001"], "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["679593333241", "684062674729", "425685993791", "582767206473", "1234567890"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-r"], "arch": "x86_64", "billing_products": ["code-0001"], "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["679593333241", "684062674729", "425685993791", "582767206473", "1234567890", "0987654321", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [    INFO] Registering image ami-1234567 with rhsm
 [   DEBUG] Searching for product RHEL_HOURLY for provider awstest in rhsm

--- a/tests/push/test_ami_push.py
+++ b/tests/push/test_ami_push.py
@@ -123,7 +123,7 @@ def test_do_push(command_tester, requests_mocker):
             "--aws-secret-key",
             "secret_key",
             "--snapshot-account-ids",
-            "1234567890",
+            "1234567890,0987654321,684062674729",
             "--ship",
             "--debug",
             AMI_SOURCE,


### PR DESCRIPTION
When I added in the --snapshot-account-ids option initially, I had
thought pubtools-ami was primarily used via commandline. It turns out
that it's actually primarily called via pub and values are injected
there. This change makes the option a list of comma separated ids, which
will be easier to store and pass from pub.