### PR TITLE
Add bandit SAST scanning job to the CI [RHELDST-12097]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -74,3 +74,35 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e docs
+  bandit-exitzero:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install RPM
+        run: |
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e bandit-exitzero
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install RPM
+        run: |
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e bandit

--- a/tox.ini
+++ b/tox.ini
@@ -47,3 +47,11 @@ commands =
     pip-compile -U --generate-hashes requirements.in
     pip-compile -U --generate-hashes requirements.in test-requirements.in -o test-requirements.txt
 # end pip-compile
+
+[testenv:bandit-exitzero]
+deps = bandit
+commands = bandit -r . -l --exclude './.tox' --exit-zero
+
+[testenv:bandit]
+deps = bandit
+commands = bandit -r . -ll --exclude './.tox'


### PR DESCRIPTION
To enable SAST scanning on this repository, Bandit has been added into the tox.ini and .github/workflows/tox-tests.yml files. Two tests are executed in the pipeline: bandit-exitzero and bandit.

The first scan lists all findings of low severity or higher and always passes due to the "exit-zero" option. This will allow tracking of low severity findings without stopping code from being merged in.

The second scan lists all findings of medium severity or higher and will fail the pipeline if any issues have been introduced.