### PR TITLE
Fix gh actions issues with Ubuntu 22.04

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -12,7 +12,7 @@ jobs:
      - name: Setup Python
        uses: actions/setup-python@v2
        with:
-         python-version: "3.9"
+         python-version: "3.8"
 
      - name: Install system dependencies
        run: |

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   py27:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install RPM


### PR DESCRIPTION
Github updated the ubuntu-latest runners to Ubuntu-22.04. This caused following issues:
* setup-python can't install py2.7 on ubuntu 22.04, so make that config stick with ubuntu 20.04
* pip-compile workflow requested python 3.9 but tox pip-compile env referred to python 3.8. This happened to work on ubuntu 20.04 because python 3.8 was always installed there by default, but this is no longer the case, so the mismatch must be corrected.