### PR TITLE
Fix compatibility with tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py36,static,docs
 [testenv]
 deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:py27]
 deps=


### PR DESCRIPTION
The term 'whitelist' must be replaced with 'allowlist' for compatibility with tox >= 4.0.0.