### PR TITLE
Drop Python2 support

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -3,7 +3,7 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py27:
+  py38:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -14,11 +14,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: 3.8
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py27
+        run: tox -e py38
   static:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -3,22 +3,6 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py38:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install RPM
-        run: |
-          sudo apt-get install -y rpm
-          sudo apt-get install -y libkrb5-dev
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install Tox
-        run: pip install tox
-      - name: Run Tox
-        run: tox -e py38
   static:
     runs-on: ubuntu-latest
     steps:

--- a/legacy.constraints
+++ b/legacy.constraints
@@ -1,7 +1,0 @@
-# Oldest supported versions of major libraries can be added to this
-# file. They'll be tested with Python 2.7.
-
-# constraints from pushsource
-attrs==17.4.0
-# constraints from pushsource, pushcollector
-jsonschema==2.3.0

--- a/pubtools/_ami/arguments.py
+++ b/pubtools/_ami/arguments.py
@@ -1,11 +1,6 @@
 import os
 from argparse import Action
 
-import six
-
-# short alias for version specific base string type
-_STRING = six.string_types[0]
-
 
 def from_environ(key, delegate_converter=lambda x: x):
     """A converter for use as an argparse "type" argument which supports
@@ -128,7 +123,7 @@ class SplitAndExtend(Action):
         # so unless this action is being used in conjunction with
         # parser.add_argument(type=<some non-string type>) this
         # should not be the case.
-        split = values.split(self.split_on) if isinstance(values, _STRING) else values
+        split = values.split(self.split_on) if isinstance(values, str) else values
         items.extend(split)
         setattr(namespace, self.dest, items)
 

--- a/pubtools/_ami/rhsm.py
+++ b/pubtools/_ami/rhsm.py
@@ -2,7 +2,7 @@ import threading
 import os
 import logging
 from datetime import datetime
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 import requests
 from more_executors import Executors

--- a/pubtools/_ami/tasks/push.py
+++ b/pubtools/_ami/tasks/push.py
@@ -7,7 +7,6 @@ import json
 import attr
 
 from requests import HTTPError
-from six import raise_from
 from more_executors import Executors
 from cloudimg.aws import AWSPublishingMetadata
 from pushsource import Source, AmiPushItem
@@ -248,7 +247,7 @@ class AmiPush(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
         try:
             image = aws.publish(publish_meta)
         except Exception as exc:  # pylint:disable=broad-except
-            raise_from(AWSPublishError(exc), exc)
+            raise AWSPublishError(exc) from exc
 
         if ship:
             self.update_rhsm_metadata(image, push_item)
@@ -264,7 +263,7 @@ class AmiPush(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
                 try:
                     aws.publish(publish_meta)
                 except Exception as exc:  # pylint:disable=broad-except
-                    raise_from(AWSPublishError(exc), exc)
+                    raise AWSPublishError(exc) from exc
 
         LOG.info("Successfully uploaded %s [%s] [%s]", name, region, image.id)
 

--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,3 @@ pushcollector
 cloudimg>=1.2.0
 attrs
 pubtools
-six

--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,11 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=get_requirements(),
-    python_requires=">=2.6",
+    python_requires=">=3.6",
     entry_points={
         "console_scripts": [
             "pubtools-ami-push = pubtools._ami.tasks.push:entry_point",

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,10 @@
 [tox]
-envlist = py27,py36,static,docs
+envlist = py38,static,docs
 
 [testenv]
 deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
 allowlist_externals=sh
-
-[testenv:py27]
-deps=
-	# Note: we need to explicitly list requirements.in here
-	# so it's processed at the same time as the constraints file
-	-rrequirements.in
-	-clegacy.constraints
-	-rtest-requirements.in
 
 [testenv:static]
 commands=


### PR DESCRIPTION
After Supercharge Pub 3 was delivered, Python 2 support is no longer required in it's dependencies as well. Dropping Python 2 will make the repos easier to maintain and will speed up Tox and Github Actions since some steps can be removed.