### PR TITLE
Drop black from github actions CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 23.1.0
     hooks:
     - id: black
       language_version: python3.8

--- a/pubtools/_ami/rhsm.py
+++ b/pubtools/_ami/rhsm.py
@@ -50,7 +50,7 @@ class RHSMClient(object):
     def _session(self):
         if not hasattr(self._tls, "session"):
             self._tls.session = requests.Session()
-            for (key, value) in self._session_attrs.items():
+            for key, value in self._session_attrs.items():
                 setattr(self._tls.session, key, value)
         return self._tls.session
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -5,7 +5,6 @@ requests_mock
 rpm-py-installer
 
 # The following deps are not relevant for the legacy test env.
-black; python_version>='3'
 pre-commit; python_version>='3'
 pylint; python_version>='3'
 sphinx; python_version>='3'

--- a/tests/command.py
+++ b/tests/command.py
@@ -136,7 +136,6 @@ class CommandTester(object):
             raise AssertionError(message)
 
     def _compare_outcome(self, records, exception):
-
         plaintext = self._get_actual_plaintext(records)
         if exception:
             plaintext += "# Raised: %s\n" % exception

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ allowlist_externals=sh
 
 [testenv:static]
 commands=
-	black --check .
 	sh -c 'pylint pubtools; test $(( $? & (1|2|4|32) )) = 0'
 
 [testenv:pidiff]


### PR DESCRIPTION
"tox -e static" previously ran the black autoformatter using a version managed by pip-compile.

Problem: pre-commit also runs black, but this uses the version defined in the pre-commit config. If there are any differences in the black code style between the two versions of the tool, they will not both be able to pass.

This recently blocked dependency updates for this repo because a new release of black is available which has some incompatibilities with the version used by pre-commit.

Rather than trying to keep both versions in sync, it makes more sense to apply the tool in just one place; so let's drop it from tox & github actions and rely only on pre-commit.ci to both run the tool and manage the version of the tool.

This commit includes an update to the pre-commit hook versions so that pre-commit.ci will be able to pass.