### PR TITLE
Share AMIs publicly based on public_image flag [RHELDST-16452]

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 more-executors
-pushsource>=2.13.3
+pushsource>=2.28.0
 pushcollector
 cloudimg>=1.2.0
 attrs

--- a/requirements.txt
+++ b/requirements.txt
@@ -350,9 +350,9 @@ pushcollector==1.3.0 \
     # via
     #   -r requirements.in
     #   pushsource
-pushsource==2.27.0 \
-    --hash=sha256:35f4e01e62652f0d2e0668cb34669a382e030d78a576ad0093834e17f1a644cf \
-    --hash=sha256:6207547298f329ef571937bb003f5df0cddf6ac7f7f5c5b6aba8ec47274c57a3
+pushsource==2.28.0 \
+    --hash=sha256:49297f06b5ef4e20da8dae6a1e19bbd2c8f1e83257d8be6dc9225885812fbe56 \
+    --hash=sha256:e4fe524c6f96b424a06cf20c690fd85b8133c9fdb7f87f2a0e7c8b85596eafff
     # via -r requirements.in
 pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -586,9 +586,9 @@ pushcollector==1.3.0 \
     # via
     #   -r requirements.in
     #   pushsource
-pushsource==2.27.0 \
-    --hash=sha256:35f4e01e62652f0d2e0668cb34669a382e030d78a576ad0093834e17f1a644cf \
-    --hash=sha256:6207547298f329ef571937bb003f5df0cddf6ac7f7f5c5b6aba8ec47274c57a3
+pushsource==2.28.0 \
+    --hash=sha256:49297f06b5ef4e20da8dae6a1e19bbd2c8f1e83257d8be6dc9225885812fbe56 \
+    --hash=sha256:e4fe524c6f96b424a06cf20c690fd85b8133c9fdb7f87f2a0e7c8b85596eafff
     # via -r requirements.in
 pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \

--- a/tests/logs/push/test_ami_push/test_aws_publish_failure_retry.txt
+++ b/tests/logs/push/test_ami_push/test_aws_publish_failure_retry.txt
@@ -16,7 +16,7 @@
 [    INFO] Attempting to update the existing image ami-1234567 in rhsm
 [   DEBUG] {"arch": "x86_64", "image_id": "ami-1234567", "image_name": "ami-rhel", "product_name": "RHEL_HOURLY", "variant": "BaseOS", "version": "8.5.0"}
 [    INFO] Successfully registered image ami-1234567 with rhsm
-[    INFO] Releasing hourly image ami-1234567 publicly
+[    INFO] Releasing image ami-1234567 publicly
 [ WARNING] Unable to publish
 [    INFO] Retrying upload
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
@@ -28,7 +28,7 @@
 [    INFO] Attempting to update the existing image ami-1234567 in rhsm
 [   DEBUG] {"arch": "x86_64", "image_id": "ami-1234567", "image_name": "ami-rhel", "product_name": "RHEL_HOURLY", "variant": "BaseOS", "version": "8.5.0"}
 [    INFO] Successfully registered image ami-1234567 with rhsm
-[    INFO] Releasing hourly image ami-1234567 publicly
+[    INFO] Releasing image ami-1234567 publicly
 [    INFO] Successfully uploaded RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2 [region-1] [ami-1234567]
 [    INFO] Collecting results
 [    INFO] AMI upload completed

--- a/tests/logs/push/test_ami_push/test_push_public_image.txt
+++ b/tests/logs/push/test_ami_push/test_push_public_image.txt
@@ -11,7 +11,7 @@
 [    INFO] Attempting to update the existing image ami-1234567 in rhsm
 [   DEBUG] {"arch": "x86_64", "image_id": "ami-1234567", "image_name": "ami-rhel", "product_name": "RHEL_HOURLY", "variant": "BaseOS", "version": "8.5.0"}
 [    INFO] Successfully registered image ami-1234567 with rhsm
-[    INFO] Releasing hourly image ami-1234567 publicly
+[    INFO] Releasing image ami-1234567 publicly
 [    INFO] Successfully uploaded RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2 [region-1] [ami-1234567]
 [    INFO] Collecting results
 [    INFO] AMI upload completed


### PR DESCRIPTION
pushsource and cloud-image-tools recently implemented the support for a flag designating whether the image should be released publicly (i.e. shared to group "all") which is set in staged metadata instead of the hardcoded rule for hourly images in pubtools-ami. This commit implements the remaining part which controls the actual behavior responsible for sharing the images publicly during pub image pushes.

As backwards-compatible behavior, the hourly images without any public_image flag set in the metadata are still considered to be public and handled as such.

This PR relates to https://github.com/release-engineering/pushsource/pull/315