### PR TITLE
Fixed prepared requests handling [RHELDST-16685]

### DIFF
--- a/pubtools/_ami/rhsm.py
+++ b/pubtools/_ami/rhsm.py
@@ -68,7 +68,7 @@ class RHSMClient(object):
             "stream": kwargs.get("stream") or None,
             "verify": kwargs.get("verify") or None,
             "cert": kwargs.get("cert") or None,
-            }
+        }
 
         merged = self._session.merge_environment_settings(**settings)
         kwargs.update(merged)

--- a/pubtools/_ami/rhsm.py
+++ b/pubtools/_ami/rhsm.py
@@ -61,8 +61,18 @@ class RHSMClient(object):
     def _get(self, *args, **kwargs):
         return self._session.get(*args, **kwargs)
 
-    def _send(self, *args, **kwargs):
-        return self._session.send(*args, **kwargs)
+    def _send(self, prepped_req, **kwargs):
+        settings = {
+            "url": prepped_req.url,
+            "proxies": kwargs.get("proxies") or None,
+            "stream": kwargs.get("stream") or None,
+            "verify": kwargs.get("verify") or None,
+            "cert": kwargs.get("cert") or None,
+            }
+
+        merged = self._session.merge_environment_settings(**settings)
+        kwargs.update(merged)
+        return self._session.send(prepped_req, **kwargs)
 
     def rhsm_products(self):
         url = urljoin(

--- a/pubtools/_ami/rhsm.py
+++ b/pubtools/_ami/rhsm.py
@@ -64,12 +64,13 @@ class RHSMClient(object):
     def _send(self, prepped_req, **kwargs):
         settings = {
             "url": prepped_req.url,
-            "proxies": kwargs.get("proxies") or None,
-            "stream": kwargs.get("stream") or None,
-            "verify": kwargs.get("verify") or None,
-            "cert": kwargs.get("cert") or None,
+            "proxies": kwargs.get("proxies"),
+            "stream": kwargs.get("stream"),
+            "verify": kwargs.get("verify"),
+            "cert": kwargs.get("cert"),
         }
-
+        # merging environment settings because prepared request doesn't take them into account
+        # details: https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests
         merged = self._session.merge_environment_settings(**settings)
         kwargs.update(merged)
         return self._session.send(prepped_req, **kwargs)


### PR DESCRIPTION
For comms with RHSM API we use prepared requests (most of calls). When sending a prepared request, environment settings are not taken into account and typical workflows fails with SSL errors simply because cert setup from env. wasn't taken into account.

To overcome this problem we need to explicitly merge environment settings before sending prepared request.