### PR TITLE
Introduce pubtools-ami-delete command [RHELDST-7515]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,6 @@
 disable=all
 
 enable=abstract-class-instantiated,
-  abstract-method,
   access-member-before-definition,
   anomalous-backslash-in-string,
   anomalous-unicode-escape-in-string,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+- Introduced new command `pubtools-ami-delete`
 
 ## [2.1.0] - 2023-03-14
 

--- a/docs/delete.rst
+++ b/docs/delete.rst
@@ -1,0 +1,59 @@
+delete
+======
+
+.. argparse::
+   :module: pubtools._ami.tasks.delete
+   :func: doc_parser
+   :prog: pubtools-ami-delete
+
+
+Example
+.......
+
+A typical invocation of delete would look like this:
+
+.. code-block::
+
+  pubtools-ami-delete \
+    --rhsm-url https://rhsm.example.com \
+    --aws-provider-name awstest \
+    --aws-access-id access_id \
+    --aws-secret-key secret_key \
+    pub:https://pub.example.com?task_id=123456
+
+All the AMIs in the given source path will be made invisible
+in RHSM and then deleted on AWS with related snapshots.
+
+
+Example: keep snapshots
+.......................
+
+Running delete while keeping snapshots untouched.
+
+.. code-block::
+
+  pubtools-ami-delete \
+    --rhsm-url https://rhsm.example.com \
+    --keep-snapshot \
+    --aws-provider-name awstest \
+    --aws-access-id access_id \
+    --aws-secret-key secret_key \
+    pub:https://pub.example.com?task_id=123456
+
+
+Example: dry-run
+................
+
+Running dry-run delete - no destructive actions happen,
+expected actions are logged.
+
+.. code-block::
+
+  pubtools-ami-delete \
+    --rhsm-url https://rhsm.example.com \
+    --dry-run \
+    --aws-provider-name awstest \
+    --aws-access-id access_id \
+    --aws-secret-key secret_key \
+    pub:https://pub.example.com?task_id=123456
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,3 +11,4 @@ Amazon Machine Images to AWS.
    :caption: Command Reference:
 
    push
+   delete

--- a/pubtools/_ami/tasks/base.py
+++ b/pubtools/_ami/tasks/base.py
@@ -1,0 +1,234 @@
+import logging
+import sys
+
+import datetime
+import json
+import attr
+
+from concurrent.futures import wait
+
+from pushsource import Source, AmiPushItem
+from pubtools._ami.task import AmiTask
+from pubtools._ami.arguments import SplitAndExtend
+from ..services import RHSMClientService, AWSPublishService, CollectorService
+from .exceptions import MissingProductError
+
+
+LOG = logging.getLogger("pubtools.ami")
+
+
+class AmiBase(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
+    """
+    Base class for AMI specific tasks that holds common logic.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._ami_push_items = None
+        self._rhsm_products = None
+        super(AmiBase, self).__init__(*args, **kwargs)
+
+    @property
+    def ami_push_items(self):
+        if self._ami_push_items is None:
+            self._ami_push_items = self._get_push_items()
+        return self._ami_push_items or None
+
+    @ami_push_items.setter
+    def ami_push_items(self, values):
+        self._ami_push_items = values
+
+    def fail(self, *args, **kwargs):
+        LOG.error(*args, **kwargs)
+        sys.exit(30)
+
+    def _get_push_items(self):
+        ami_push_items = []
+        for source_loc in self.args.source:
+            with Source.get(source_loc) as source:
+                for push_item in source:
+                    if not isinstance(push_item, AmiPushItem):
+                        LOG.warning(
+                            "Push Item %s at %s is not an AmiPushItem. "
+                            "Dropping it from the queue",
+                            push_item.name,
+                            push_item.src,
+                        )
+                        continue
+                    ami_push_items.append(push_item)
+        return ami_push_items
+
+    def add_args(self):
+        super(AmiBase, self).add_args()
+
+        group = self.parser.add_argument_group("AMI common options")
+        group.add_argument(
+            "source",
+            nargs="+",
+            help="source location of the staged AMIs with the source type. "
+            "e.g. staged:/path/to/stage/ami or "
+            "errata:https://errata.example.com?errata=RHBA-2020:1234 or "
+            "pub:https://pub.example.com?task_id=125222",
+            action=SplitAndExtend,
+            split_on=",",
+        )
+
+        group.add_argument(
+            "--aws-provider-name",
+            help="AWS provider e.g. AWS, ACN (AWS China), AGOV (AWS US Gov)",
+            default="AWS",
+        )
+
+        group.add_argument(
+            "--retry-wait",
+            help="duration to wait in sec before retrying action on AWS",
+            type=int,
+            default=30,
+        )
+
+        group.add_argument(
+            "--max-retries",
+            help="number of retries on failure with action on AWS",
+            type=int,
+            default=4,
+        )
+
+    def region_data(self):
+        """Aggregate push_items for each item and region
+        for various destinations
+        """
+        region_data = {}
+        for item in self.ami_push_items:
+            for _ in item.dest:
+                region = item.region
+                region_data.setdefault((item, region), []).append({"push_item": item})
+        return region_data.values()
+
+    def collect_push_result(self, results):
+        """Collects the push results and sends its json to the collector"""
+        RESULT_KEY_MAPPING = {
+            "ami": "image_id",
+            "name": "image_name",
+            "snapshot_id": "snapshot_id",
+        }
+
+        def convert(obj):
+            if isinstance(obj, (datetime.datetime, datetime.date)):
+                return obj.strftime("%Y%m%d")
+
+        mod_result = []
+        push_items = []
+        for result in results:
+            push_items.append(self._pushitem_for_ami(result["push_item"]))
+            res_dict = attr.asdict(result["push_item"])
+            # dict can't be modified during iteration.
+            # so iterate over list of keys.
+            for key in list(res_dict):
+                if res_dict[key] is None:
+                    del res_dict[key]
+
+            for k, v in RESULT_KEY_MAPPING.items():
+                if v in result:
+                    res_dict[k] = result[v]
+
+            mod_result.append(res_dict)
+
+        metadata = json.dumps(mod_result, default=convert, indent=2, sort_keys=True)
+        wait(
+            [
+                self.collector.attach_file("images.json", metadata),
+                self.collector.update_push_items(push_items),
+            ]
+        )
+
+    def _pushitem_for_ami(self, ami_item):
+        return {
+            "filename": f"{ami_item.image_id}",
+            "state": f"{ami_item.state}",
+        }
+
+    def name_from_metadata(self, push_item):
+        """
+        Constructs an image name from the metadata.
+        """
+        parts = []
+        release = push_item.release
+
+        if release.base_product is not None:
+            parts.append(release.base_product)
+            if release.base_version is not None:
+                parts.append(release.base_version)
+
+        parts.append(release.product)
+
+        # Some attributes should be separated by underscores
+        underscore_parts = []
+
+        if release.version is not None:
+            underscore_parts.append(release.version)
+
+        underscore_parts.append(push_item.virtualization.upper())
+
+        if release.type is not None:
+            underscore_parts.append(release.type.upper())
+
+        parts.append("_".join(underscore_parts))
+
+        parts.append(release.date.strftime("%Y%m%d"))
+        parts.append(release.arch)
+        parts.append(str(release.respin))
+        parts.append(push_item.billing_codes.name)
+        parts.append(push_item.volume.upper())
+
+        return "-".join(parts)
+
+    def to_rhsm_product(self, product, image_type):
+        """Product info from rhsm for the specified product in metadata"""
+        # The rhsm prodcut should always be the product (short) plus
+        # "_HOURLY" for hourly type images.
+        image_type = image_type.upper()
+        aws_provider_name = self.args.aws_provider_name
+        if image_type == "HOURLY":
+            product = product + "_" + image_type
+
+        LOG.debug(
+            "Searching for product %s for provider %s in rhsm",
+            product,
+            aws_provider_name,
+        )
+        for rhsm_product in self.rhsm_products:
+            if (
+                rhsm_product["name"] == product
+                and rhsm_product["providerShortName"] == aws_provider_name
+            ):
+                return rhsm_product
+
+        raise MissingProductError("Product not in rhsm: %s" % product)
+
+    @property
+    def rhsm_products(self):
+        """List of products/image groups for all the service providers"""
+        if self._rhsm_products is None:
+            response = self.rhsm_client.rhsm_products().result()
+            self._rhsm_products = response.json()["body"]
+            prod_names = [
+                "%s(%s)" % (p["name"], p["providerShortName"])
+                for p in self._rhsm_products
+            ]
+            LOG.debug(
+                "%s Products(AWS provider) in rhsm: %s",
+                len(prod_names),
+                ", ".join(sorted(prod_names)),
+            )
+        return self._rhsm_products
+
+    def in_rhsm(self, product, image_type):
+        """Checks whether the product is present in rhsm for the provider.
+        Returns True if the product is found in rhsm_products else False.
+        """
+        try:
+            self.to_rhsm_product(product, image_type)
+        except MissingProductError as er:
+            LOG.error(er)
+            return False
+
+        return True

--- a/pubtools/_ami/tasks/delete.py
+++ b/pubtools/_ami/tasks/delete.py
@@ -1,0 +1,253 @@
+import logging
+import os
+from concurrent.futures import as_completed
+
+import attr
+from cloudimg.aws import AWSDeleteMetadata
+from more_executors import Executors, ExceptionRetryPolicy
+
+from pubtools._ami.arguments import SplitAndExtend
+
+from ..services import AWSPublishService, CollectorService, RHSMClientService
+from .base import AmiBase
+from .exceptions import AWSDeleteError
+from pubtools._ami.task import AmiTask
+
+LOG = logging.getLogger("pubtools.ami")
+
+step = AmiTask.step
+
+
+class AmiDelete(AmiBase, RHSMClientService, AWSPublishService, CollectorService):
+    """Deletes one or more Amazon Machine Images on AWS from specified sources.
+
+    This command gets the AMIs from specified source, checks the image presence
+    in metadata service (e.g. RHSM) and makes image invisible in this service.
+    This is followed by deletion of image and related snapshot in AWS.
+    """
+
+    _REQUEST_THREADS = int(os.environ.get("AMI_DELETE_REQUEST_THREADS", "5"))
+
+    def __init__(self, *args, **kwargs):
+        self._rhsm_products = None
+        super(AmiDelete, self).__init__(*args, **kwargs)
+
+    def add_args(self):
+        super(AmiDelete, self).add_args()
+
+        group = self.parser.add_argument_group("AMI delete options")
+
+        group.add_argument(
+            "--keep-snapshot",
+            help="Do not delete snapshot from AWS",
+            action="store_true",
+        )
+
+        group.add_argument(
+            "--dry-run",
+            help="Skip destructive actions on rhsm or AWS",
+            action="store_true",
+        )
+
+        group.add_argument(
+            "--limit",
+            nargs="+",
+            help="Only remove the specified AMIs by AMI image id",
+            action=SplitAndExtend,
+            split_on=",",
+        )
+
+    def _delete_in_region(self, region_data):
+        for dest_data in region_data:
+            push_item = dest_data["push_item"]
+            state = push_item.state
+            if self.args.dry_run:
+                LOG.info(
+                    "Would have deleted image %s and related snapshot in AWS (%s)",
+                    push_item.image_id,
+                    self.args.aws_provider_name,
+                )
+                continue
+
+            image_id, snapshot_id = self._delete(push_item)
+            if image_id or snapshot_id:
+                state = "DELETED"
+            else:
+                state = "MISSING"
+
+            dest_data["push_item"] = attr.evolve(push_item, state=state)
+            dest_data["state"] = state
+            dest_data["image_id"] = image_id
+            dest_data["snapshot_id"] = snapshot_id
+
+        return region_data
+
+    def _delete(self, push_item):
+        """
+        Request deletion on AWS for single AMI push_item.
+
+        Deletion of both image and related snapshot is attempted
+        and if succesfull, ids of removed image and snapshot are returned.
+
+        Deletion of snapshot can be skipped by providing --keep-snapshot arg.
+        """
+        region = push_item.region
+        name = self.name_from_metadata(push_item)
+        LOG.info(
+            "Attempting to delete image %s and related snapshot on AWS (%s)",
+            name,
+            self.args.aws_provider_name,
+        )
+        delete_meta_kwargs = {
+            "image_id": push_item.image_id,
+            "image_name": name,
+            # currently using getattr for snapshot_id/name because
+            # snapshot related fields are not available in pushitem
+            "snapshot_id": getattr(push_item, "snapshot_id", None),
+            "snapshot_name": getattr(push_item, "snapshot_name", name),
+            "skip_snapshot": self.args.keep_snapshot,
+        }
+        metadata = AWSDeleteMetadata(**delete_meta_kwargs)
+
+        aws = self.aws_service(region)
+        try:
+            out = aws.delete(metadata)
+        except Exception as exc:  # pylint:disable=broad-except
+            LOG.error("AWS delete failed for AMI %s", push_item.image_id)
+            raise AWSDeleteError(exc) from exc
+
+        deleted_image_id, deleted_snapshot_id = out
+        if deleted_image_id:
+            LOG.info(
+                "Successfully deleted image: %s [%s] [%s]",
+                name,
+                region,
+                deleted_image_id,
+            )
+        if deleted_snapshot_id:
+            LOG.info(
+                "Successfully deleted snapshot: %s [%s] [%s]",
+                name,
+                region,
+                deleted_snapshot_id,
+            )
+
+        return deleted_image_id, deleted_snapshot_id
+
+    @step("Prepare data")
+    def limit_push_items(self):
+        """
+        If --limit arg is provided, attempt deletion only
+        for specified AMIs.
+        """
+        filtered_push_items = []
+        if self.args.limit:
+            for item in self.ami_push_items:
+                if item.image_id in self.args.limit:
+                    filtered_push_items.append(item)
+
+            self.ami_push_items = filtered_push_items
+
+    @step("Update RHSM metadata")
+    def update_rhsm_metadata(self):
+        """
+        Sets images as 'INVISIBLE' in RHSM metadata service, if the image
+        is present. Missing image isn't counted as a fatal error.
+        """
+        rhsm_image_ids = self.rhsm_client.list_image_ids()
+
+        for item in self.ami_push_items:
+            if item.image_id not in rhsm_image_ids:
+                LOG.warning(
+                    "AMI image: %s not found, skipping update in rhsm.", item.image_id
+                )
+            else:
+                image_meta = {
+                    "image_id": item.image_id,
+                    "image_name": item.name,
+                    "arch": item.release.arch,
+                    "product_name": self.to_rhsm_product(
+                        item.release.product, item.type
+                    )["name"],
+                    "version": item.release.version or None,
+                    "variant": item.release.variant or None,
+                    "status": "invisible",
+                }
+                if self.args.dry_run:
+                    LOG.info("Would have updated image %s in rhsm", item.image_id)
+                    continue
+
+                LOG.info(
+                    "Attempting to update the existing image %s in rhsm", item.image_id
+                )
+                out = self.rhsm_client.update_image(**image_meta)
+                resp = out.result()
+                if not resp.ok:
+                    LOG.error("Failed updating image %s", item.image_id)
+                    resp.raise_for_status()
+
+                LOG.info("Existing image %s succesfully updated in rhsm", item.image_id)
+
+    @step("Delete AWS data")
+    def do_delete(self):
+        # split push_items into regions
+        region_data = self.region_data()
+        to_await = []
+        result = []
+        failure = False
+
+        # run the actual delete in aws
+        with Executors.thread_pool(
+            name="pubtools-ami-delete",
+            max_workers=min(len(region_data), self._REQUEST_THREADS),
+        ).with_retry(
+            logger=LOG,
+            retry_policy=ExceptionRetryPolicy(
+                sleep=self.args.retry_wait,
+                max_attempts=self.args.max_retries,
+            ),
+        ) as executor:
+            for data in region_data:
+                to_await.append(executor.submit(self._delete_in_region, data))
+
+            # waiting for results
+            for f_out in as_completed(to_await):
+                try:
+                    result.extend(f_out.result())
+                except Exception as exc:  # pylint:disable=broad-except
+                    LOG.exception("AMI delete failed", exc_info=exc)
+                    failure = True
+
+        return failure, result
+
+    def run(self):
+        self.limit_push_items()
+        if not self.ami_push_items:
+            LOG.info("No AMI image selected for deletion")
+            return
+
+        # set images in rhsm as invisible
+        self.update_rhsm_metadata()
+
+        # perform deletion on AWS
+        failure, result = self.do_delete()
+
+        if self.args.dry_run:
+            LOG.info("AMI delete dry-run completed")
+        else:
+            # send to collector
+            LOG.info("Collecting results")
+            self.collect_push_result(result)
+
+            if failure:
+                self.fail("AMI delete finished with failure")
+
+            LOG.info("AMI delete completed")
+
+
+def entry_point(cls=AmiDelete):
+    cls().main()
+
+
+def doc_parser():
+    return AmiDelete().parser

--- a/pubtools/_ami/tasks/exceptions.py
+++ b/pubtools/_ami/tasks/exceptions.py
@@ -1,0 +1,10 @@
+class AWSPublishError(Exception):
+    """Exception class for AWS publish errors"""
+
+
+class AWSDeleteError(Exception):
+    """Exception class for AWS delete errors"""
+
+
+class MissingProductError(Exception):
+    """Exception class for products missing in the metadata service"""

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 more-executors
 pushsource>=2.28.0
 pushcollector
-cloudimg>=1.2.0
+cloudimg>=1.5.0
 attrs
 pubtools

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     entry_points={
         "console_scripts": [
             "pubtools-ami-push = pubtools._ami.tasks.push:entry_point",
+            "pubtools-ami-delete = pubtools._ami.tasks.delete:entry_point",
         ]
     },
     project_urls={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def fake_collector():
     yield collector
 
     Collector.set_default_backend(None)
+    Collector.register_backend("pubtools-ami-test", None)
 
 
 @pytest.fixture

--- a/tests/logs/push/test_ami_delete/test_ami_delete_aws_failure.jsonl
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_aws_failure.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "prepare-data-start"}}
+{"event": {"type": "prepare-data-end"}}
+{"event": {"type": "update-rhsm-metadata-start"}}
+{"event": {"type": "update-rhsm-metadata-end"}}
+{"event": {"type": "delete-aws-data-start"}}
+{"event": {"type": "delete-aws-data-end"}}

--- a/tests/logs/push/test_ami_delete/test_ami_delete_aws_failure.txt
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_aws_failure.txt
@@ -1,0 +1,20 @@
+[    INFO] Prepare data: started
+[    INFO] Prepare data: finished
+[    INFO] Update RHSM metadata: started
+[   DEBUG] Listing all images from rhsm, https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/amis
+[   DEBUG] Searching for product fake-product for provider awstest in rhsm
+[   DEBUG] Fetching product from https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
+[   DEBUG] 1 Products(AWS provider) in rhsm: fake-product(awstest)
+[    INFO] Attempting to update the existing image ami-fake-id-01-aws-failure in rhsm
+[    INFO] Existing image ami-fake-id-01-aws-failure succesfully updated in rhsm
+[    INFO] Update RHSM metadata: finished
+[    INFO] Delete AWS data: started
+[    INFO] Attempting to delete image fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME and related snapshot on AWS (awstest)
+[   ERROR] AWS delete failed for AMI ami-fake-id-01-aws-failure
+[    INFO] Attempting to delete image fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME and related snapshot on AWS (awstest)
+[   ERROR] AWS delete failed for AMI ami-fake-id-01-aws-failure
+[   ERROR] AMI delete failed
+[    INFO] Delete AWS data: finished
+[    INFO] Collecting results
+[   ERROR] AMI delete finished with failure
+# Raised: 30

--- a/tests/logs/push/test_ami_delete/test_ami_delete_dry_run.jsonl
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_dry_run.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "prepare-data-start"}}
+{"event": {"type": "prepare-data-end"}}
+{"event": {"type": "update-rhsm-metadata-start"}}
+{"event": {"type": "update-rhsm-metadata-end"}}
+{"event": {"type": "delete-aws-data-start"}}
+{"event": {"type": "delete-aws-data-end"}}

--- a/tests/logs/push/test_ami_delete/test_ami_delete_dry_run.txt
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_dry_run.txt
@@ -1,0 +1,15 @@
+[    INFO] Prepare data: started
+[    INFO] Prepare data: finished
+[    INFO] Update RHSM metadata: started
+[   DEBUG] Listing all images from rhsm, https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/amis
+[   DEBUG] Searching for product fake-product for provider awstest in rhsm
+[   DEBUG] Fetching product from https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
+[   DEBUG] 1 Products(AWS provider) in rhsm: fake-product(awstest)
+[    INFO] Would have updated image ami-fake-id-01 in rhsm
+[ WARNING] AMI image: ami-fake-id-02 not found, skipping update in rhsm.
+[    INFO] Update RHSM metadata: finished
+[    INFO] Delete AWS data: started
+[    INFO] Would have deleted image ami-fake-id-01 and related snapshot in AWS (awstest)
+[    INFO] Would have deleted image ami-fake-id-02 and related snapshot in AWS (awstest)
+[    INFO] Delete AWS data: finished
+[    INFO] AMI delete dry-run completed

--- a/tests/logs/push/test_ami_delete/test_ami_delete_limit.jsonl
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_limit.jsonl
@@ -1,0 +1,2 @@
+{"event": {"type": "prepare-data-start"}}
+{"event": {"type": "prepare-data-end"}}

--- a/tests/logs/push/test_ami_delete/test_ami_delete_limit.txt
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_limit.txt
@@ -1,0 +1,3 @@
+[    INFO] Prepare data: started
+[    INFO] Prepare data: finished
+[    INFO] No AMI image selected for deletion

--- a/tests/logs/push/test_ami_delete/test_ami_delete_missing_image_in_aws.jsonl
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_missing_image_in_aws.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "prepare-data-start"}}
+{"event": {"type": "prepare-data-end"}}
+{"event": {"type": "update-rhsm-metadata-start"}}
+{"event": {"type": "update-rhsm-metadata-end"}}
+{"event": {"type": "delete-aws-data-start"}}
+{"event": {"type": "delete-aws-data-end"}}

--- a/tests/logs/push/test_ami_delete/test_ami_delete_missing_image_in_aws.txt
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_missing_image_in_aws.txt
@@ -1,0 +1,15 @@
+[    INFO] Prepare data: started
+[    INFO] Prepare data: finished
+[    INFO] Update RHSM metadata: started
+[   DEBUG] Listing all images from rhsm, https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/amis
+[   DEBUG] Searching for product fake-product for provider awstest in rhsm
+[   DEBUG] Fetching product from https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
+[   DEBUG] 1 Products(AWS provider) in rhsm: fake-product(awstest)
+[    INFO] Attempting to update the existing image ami-fake-id-01 in rhsm
+[    INFO] Existing image ami-fake-id-01 succesfully updated in rhsm
+[    INFO] Update RHSM metadata: finished
+[    INFO] Delete AWS data: started
+[    INFO] Attempting to delete image fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME and related snapshot on AWS (awstest)
+[    INFO] Delete AWS data: finished
+[    INFO] Collecting results
+[    INFO] AMI delete completed

--- a/tests/logs/push/test_ami_delete/test_ami_delete_missing_image_in_rhsm.jsonl
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_missing_image_in_rhsm.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "prepare-data-start"}}
+{"event": {"type": "prepare-data-end"}}
+{"event": {"type": "update-rhsm-metadata-start"}}
+{"event": {"type": "update-rhsm-metadata-end"}}
+{"event": {"type": "delete-aws-data-start"}}
+{"event": {"type": "delete-aws-data-end"}}

--- a/tests/logs/push/test_ami_delete/test_ami_delete_missing_image_in_rhsm.txt
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_missing_image_in_rhsm.txt
@@ -1,0 +1,13 @@
+[    INFO] Prepare data: started
+[    INFO] Prepare data: finished
+[    INFO] Update RHSM metadata: started
+[   DEBUG] Listing all images from rhsm, https://example.com/v1/internal/cloud_access_providers/amazon/amis
+[ WARNING] AMI image: ami-fake-id-01-not-in-rhsm not found, skipping update in rhsm.
+[    INFO] Update RHSM metadata: finished
+[    INFO] Delete AWS data: started
+[    INFO] Attempting to delete image fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME and related snapshot on AWS (awstest)
+[    INFO] Successfully deleted image: fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME [awstest] [ami-fake-id-01-not-in-rhsm]
+[    INFO] Successfully deleted snapshot: fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME [awstest] [snap-fake-id-01-not-in-rhsm]
+[    INFO] Delete AWS data: finished
+[    INFO] Collecting results
+[    INFO] AMI delete completed

--- a/tests/logs/push/test_ami_delete/test_ami_delete_rhsm_failure.jsonl
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_rhsm_failure.jsonl
@@ -1,0 +1,4 @@
+{"event": {"type": "prepare-data-start"}}
+{"event": {"type": "prepare-data-end"}}
+{"event": {"type": "update-rhsm-metadata-start"}}
+{"event": {"type": "update-rhsm-metadata-error"}}

--- a/tests/logs/push/test_ami_delete/test_ami_delete_rhsm_failure.txt
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_rhsm_failure.txt
@@ -1,0 +1,11 @@
+[    INFO] Prepare data: started
+[    INFO] Prepare data: finished
+[    INFO] Update RHSM metadata: started
+[   DEBUG] Listing all images from rhsm, https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/amis
+[   DEBUG] Searching for product fake-product for provider awstest in rhsm
+[   DEBUG] Fetching product from https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
+[   DEBUG] 1 Products(AWS provider) in rhsm: fake-product(awstest)
+[    INFO] Attempting to update the existing image ami-fake-id-01-rhsm-failure in rhsm
+[   ERROR] Failed updating image ami-fake-id-01-rhsm-failure
+[   ERROR] Update RHSM metadata: failed
+# Raised: 500 Server Error: None for url: https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/amis

--- a/tests/logs/push/test_ami_delete/test_ami_delete_typical[keep_snapshot_false].jsonl
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_typical[keep_snapshot_false].jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "prepare-data-start"}}
+{"event": {"type": "prepare-data-end"}}
+{"event": {"type": "update-rhsm-metadata-start"}}
+{"event": {"type": "update-rhsm-metadata-end"}}
+{"event": {"type": "delete-aws-data-start"}}
+{"event": {"type": "delete-aws-data-end"}}

--- a/tests/logs/push/test_ami_delete/test_ami_delete_typical[keep_snapshot_false].txt
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_typical[keep_snapshot_false].txt
@@ -1,0 +1,17 @@
+[    INFO] Prepare data: started
+[    INFO] Prepare data: finished
+[    INFO] Update RHSM metadata: started
+[   DEBUG] Listing all images from rhsm, https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/amis
+[   DEBUG] Searching for product fake-product for provider awstest in rhsm
+[   DEBUG] Fetching product from https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
+[   DEBUG] 1 Products(AWS provider) in rhsm: fake-product(awstest)
+[    INFO] Attempting to update the existing image ami-fake-id-01 in rhsm
+[    INFO] Existing image ami-fake-id-01 succesfully updated in rhsm
+[    INFO] Update RHSM metadata: finished
+[    INFO] Delete AWS data: started
+[    INFO] Attempting to delete image fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME and related snapshot on AWS (awstest)
+[    INFO] Successfully deleted image: fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME [awstest] [ami-fake-id-01]
+[    INFO] Successfully deleted snapshot: fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME [awstest] [snap-fake-id-01]
+[    INFO] Delete AWS data: finished
+[    INFO] Collecting results
+[    INFO] AMI delete completed

--- a/tests/logs/push/test_ami_delete/test_ami_delete_typical[keep_snapshot_true].jsonl
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_typical[keep_snapshot_true].jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "prepare-data-start"}}
+{"event": {"type": "prepare-data-end"}}
+{"event": {"type": "update-rhsm-metadata-start"}}
+{"event": {"type": "update-rhsm-metadata-end"}}
+{"event": {"type": "delete-aws-data-start"}}
+{"event": {"type": "delete-aws-data-end"}}

--- a/tests/logs/push/test_ami_delete/test_ami_delete_typical[keep_snapshot_true].txt
+++ b/tests/logs/push/test_ami_delete/test_ami_delete_typical[keep_snapshot_true].txt
@@ -1,0 +1,16 @@
+[    INFO] Prepare data: started
+[    INFO] Prepare data: finished
+[    INFO] Update RHSM metadata: started
+[   DEBUG] Listing all images from rhsm, https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/amis
+[   DEBUG] Searching for product fake-product for provider awstest in rhsm
+[   DEBUG] Fetching product from https://rhsm.example.com/v1/internal/cloud_access_providers/amazon/provider_image_groups
+[   DEBUG] 1 Products(AWS provider) in rhsm: fake-product(awstest)
+[    INFO] Attempting to update the existing image ami-fake-id-01 in rhsm
+[    INFO] Existing image ami-fake-id-01 succesfully updated in rhsm
+[    INFO] Update RHSM metadata: finished
+[    INFO] Delete AWS data: started
+[    INFO] Attempting to delete image fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME and related snapshot on AWS (awstest)
+[    INFO] Successfully deleted image: fake-product-FAKE-VIRT-20230306-fake-arch-1-fake-bc-FAKE-VOLUME [awstest] [ami-fake-id-01]
+[    INFO] Delete AWS data: finished
+[    INFO] Collecting results
+[    INFO] AMI delete completed

--- a/tests/push/test_ami_delete.py
+++ b/tests/push/test_ami_delete.py
@@ -1,0 +1,564 @@
+import json
+import re
+
+import pytest
+from mock import patch
+from pushsource import AmiBillingCodes, AmiPushItem, AmiRelease, Source
+
+from pubtools._ami.tasks.delete import AmiDelete, entry_point
+
+
+@pytest.fixture()
+def mock_aws_delete():
+    with patch("pubtools._ami.services.aws.AWSService.delete") as m:
+        yield m
+
+
+def _setup_rhsm_api_mocks(
+    requests_mocker,
+    rhsm_ami_ids,
+    dry_run=False,
+):
+    requests_mocker.register_uri(
+        "GET",
+        "/v1/internal/cloud_access_providers/amazon/amis",
+        [
+            {
+                "json": {
+                    "pagination": {"count": len(rhsm_ami_ids)},
+                    "body": [{"amiID": ami_id} for ami_id in rhsm_ami_ids],
+                },
+                "status_code": 200,
+            },
+            {
+                "json": {
+                    "pagination": {"count": 0},
+                    "body": [{}],
+                },
+                "status_code": 200,
+            },
+        ],
+    )
+
+    requests_mocker.register_uri(
+        "GET",
+        "/v1/internal/cloud_access_providers/amazon/provider_image_groups",
+        status_code=200,
+        json={"body": [{"name": "fake-product", "providerShortName": "awstest"}]},
+    )
+
+    if not dry_run:
+        requests_mocker.register_uri("PUT", re.compile("amazon/amis"))
+
+
+@pytest.mark.parametrize(
+    "keep_snapshot", [False, True], ids=["keep_snapshot_false", "keep_snapshot_true"]
+)
+def test_ami_delete_typical(
+    command_tester,
+    requests_mocker,
+    mock_aws_delete,
+    keep_snapshot,
+    fake_collector,
+):
+    """
+    Tests basic AMI delete workflow. Image is updated in rhsm and image with snapshot
+    are deleted from AWS. Also tests a variant with --keep-snapshot arg provided.
+    """
+
+    fake_items = [
+        AmiPushItem(
+            name="fake-name",
+            image_id="ami-fake-id-01",
+            description="fake-descr-01",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+        AmiPushItem(
+            name="fake-name",
+            image_id="ami-fake-id-02",
+            description="fake-descr-02",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+    ]
+
+    Source.register_backend("fake", lambda: fake_items)
+
+    mock_aws_delete.return_value = (
+        "ami-fake-id-01",
+        None if keep_snapshot else "snap-fake-id-01",
+    )
+    _setup_rhsm_api_mocks(requests_mocker, ["ami-fake-id-01"])
+
+    cmd_args = [
+        "test-delete",
+        "--rhsm-url",
+        "https://rhsm.example.com",
+        "fake:",
+        "--aws-access-id",
+        "access_id",
+        "--aws-secret-key",
+        "secret_key",
+        "--debug",
+        "--aws-provider-name",
+        "awstest",
+        "--limit",
+        "ami-fake-id-01",
+    ]
+
+    if keep_snapshot:
+        cmd_args.append("--keep-snapshot")
+    command_tester.test(lambda: entry_point(AmiDelete), cmd_args)
+
+    mock_aws_delete.assert_called_once()
+    meta = mock_aws_delete.call_args[0][0]
+
+    # check what metadata was passed to AWS API call
+    assert meta.image_id == "ami-fake-id-01"
+    assert meta.skip_snapshot is keep_snapshot
+
+    # check stored push items and images.json file content
+    stored_push_items = fake_collector.items
+
+    assert len(stored_push_items) == 1
+    pushitem = stored_push_items[0]
+    assert pushitem["filename"] == "ami-fake-id-01"
+    assert pushitem["state"] == "DELETED"
+
+    images_json = json.loads(fake_collector.file_content["images.json"])
+    assert images_json[0]["image_id"] == "ami-fake-id-01"
+    assert images_json[0]["snapshot_id"] == None if keep_snapshot else "snap-fake-id-01"
+
+
+def test_ami_delete_missing_image_in_aws(
+    requests_mocker,
+    command_tester,
+    mock_aws_delete,
+    fake_collector,
+):
+    """
+    Tests basic AMI delete workflow when the image requseted for deletions is missing from AWS.
+    Image is updated in rhsm and but skipped from deletion in AWS.
+    """
+
+    fake_items = [
+        AmiPushItem(
+            name="fake-name",
+            image_id="ami-fake-id-01",
+            description="fake-descr-01",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+    ]
+
+    Source.register_backend("fake", lambda: fake_items)
+
+    mock_aws_delete.return_value = (
+        None,
+        None,
+    )
+    _setup_rhsm_api_mocks(requests_mocker, ["ami-fake-id-01"])
+
+    cmd_args = [
+        "test-delete",
+        "--rhsm-url",
+        "https://rhsm.example.com",
+        "fake:",
+        "--aws-access-id",
+        "access_id",
+        "--aws-secret-key",
+        "secret_key",
+        "--debug",
+        "--aws-provider-name",
+        "awstest",
+        "--limit",
+        "ami-fake-id-01",
+    ]
+
+    command_tester.test(lambda: entry_point(AmiDelete), cmd_args)
+
+    mock_aws_delete.assert_called_once()
+    meta = mock_aws_delete.call_args[0][0]
+
+    # check what metadata was passed to AWS API call
+    assert meta.image_id == "ami-fake-id-01"
+
+    # check stored push items and images.json file content
+    stored_push_items = fake_collector.items
+
+    assert len(stored_push_items) == 1
+    pushitem = stored_push_items[0]
+    assert pushitem["filename"] == "ami-fake-id-01"
+    assert pushitem["state"] == "MISSING"
+
+    images_json = json.loads(fake_collector.file_content["images.json"])
+    assert images_json[0]["image_id"] == "ami-fake-id-01"
+    assert images_json[0]["snapshot_id"] is None
+
+
+def test_ami_delete_dry_run(
+    command_tester, requests_mocker, mock_aws_delete, fake_collector
+):
+    """
+    Tests dry run for pubtools-ami-delete, no destructive action is done.
+    """
+
+    fake_items = [
+        AmiPushItem(
+            name="fake-name-01",
+            image_id="ami-fake-id-01",
+            description="fake-descr-01",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+        AmiPushItem(
+            name="fake-name-02",
+            image_id="ami-fake-id-02",
+            description="fake-descr-02",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+    ]
+
+    Source.register_backend("fake", lambda: fake_items)
+
+    _setup_rhsm_api_mocks(
+        requests_mocker,
+        ["ami-fake-id-01"],
+        dry_run=True,
+    )
+
+    command_tester.test(
+        lambda: entry_point(AmiDelete),
+        [
+            "test-delete",
+            "--dry-run",
+            "--rhsm-url",
+            "https://rhsm.example.com",
+            "fake:",
+            "--aws-access-id",
+            "access_id",
+            "--aws-secret-key",
+            "secret_key",
+            "--debug",
+            "--aws-provider-name",
+            "awstest",
+        ],
+    )
+
+    # delete in AWS shouldn't have been called at all
+    mock_aws_delete.assert_not_called()
+
+    # check stored push items and images.json file content
+    stored_push_items = fake_collector.items
+
+    assert len(stored_push_items) == 0
+    assert fake_collector.file_content.get("images.json") is None
+
+
+def test_ami_delete_missing_image_in_rhsm(
+    command_tester, requests_mocker, mock_aws_delete, fake_collector
+):
+    """
+    Tests a variant when image is not found is rhsm,
+    in this case processing continues only with warning logged.
+    """
+
+    fake_items = [
+        AmiPushItem(
+            name="fake-name",
+            image_id="ami-fake-id-01-not-in-rhsm",
+            description="fake-descr-01",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+    ]
+
+    Source.register_backend("fake", lambda: fake_items)
+
+    _setup_rhsm_api_mocks(
+        requests_mocker,
+        ["ami-fake-id-unknown"],
+    )
+
+    mock_aws_delete.return_value = (
+        "ami-fake-id-01-not-in-rhsm",
+        "snap-fake-id-01-not-in-rhsm",
+    )
+    command_tester.test(
+        lambda: entry_point(AmiDelete),
+        [
+            "test-delete",
+            "--rhsm-url",
+            "https://example.com",
+            "fake:",
+            "--aws-access-id",
+            "access_id",
+            "--aws-secret-key",
+            "secret_key",
+            "--debug",
+            "--aws-provider-name",
+            "awstest",
+        ],
+    )
+
+    mock_aws_delete.assert_called_once()
+    meta = mock_aws_delete.call_args[0][0]
+
+    # check what metadata was passed to AWS API call
+    assert meta.image_id == "ami-fake-id-01-not-in-rhsm"
+    assert meta.skip_snapshot is False
+
+    # check stored push items and images.json file content
+    stored_push_items = fake_collector.items
+
+    assert len(stored_push_items) == 1
+    pushitem = stored_push_items[0]
+    assert pushitem["filename"] == "ami-fake-id-01-not-in-rhsm"
+    assert pushitem["state"] == "DELETED"
+
+    images_json = json.loads(fake_collector.file_content["images.json"])
+    assert images_json[0]["image_id"] == "ami-fake-id-01-not-in-rhsm"
+    assert images_json[0]["snapshot_id"] == "snap-fake-id-01-not-in-rhsm"
+
+
+def test_ami_delete_aws_failure(
+    command_tester, requests_mocker, mock_aws_delete, fake_collector
+):
+    """
+    Tests a variant when error is raised during deletion on AWS.
+    """
+
+    fake_items = [
+        AmiPushItem(
+            name="fake-name",
+            image_id="ami-fake-id-01-aws-failure",
+            description="fake-descr-01",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+    ]
+
+    Source.register_backend("fake", lambda: fake_items)
+
+    _setup_rhsm_api_mocks(
+        requests_mocker,
+        ["ami-fake-id-01-aws-failure"],
+    )
+
+    mock_aws_delete.side_effect = Exception("AWS operation failed miserably!")
+
+    cmd_args = [
+        "test-delete",
+        "--rhsm-url",
+        "https://rhsm.example.com",
+        "fake:",
+        "--aws-access-id",
+        "access_id",
+        "--aws-secret-key",
+        "secret_key",
+        "--debug",
+        "--aws-provider-name",
+        "awstest",
+        "--retry-wait",
+        "1",
+        "--max-retries",
+        "2",
+    ]
+
+    command_tester.test(lambda: entry_point(AmiDelete), cmd_args)
+
+    # mock was called twice due to retries
+    assert len(mock_aws_delete.call_args_list) == 2
+
+    for call_args in mock_aws_delete.call_args_list:
+        meta = call_args[0][0]
+
+        # check what metadata was passed to AWS API call
+        assert meta.image_id == "ami-fake-id-01-aws-failure"
+        assert meta.skip_snapshot is False
+
+    # check stored push items and images.json file content
+    stored_push_items = fake_collector.items
+
+    assert len(stored_push_items) == 0
+    assert len(json.loads(fake_collector.file_content.get("images.json"))) == 0
+
+
+def test_ami_delete_rhsm_failure(
+    command_tester, requests_mocker, mock_aws_delete, fake_collector
+):
+    """
+    Tests a variant when error is raised during update on rhsm.
+    """
+
+    fake_items = [
+        AmiPushItem(
+            name="fake-name",
+            image_id="ami-fake-id-01-rhsm-failure",
+            description="fake-descr-01",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+    ]
+    Source.register_backend("fake", lambda: fake_items)
+
+    _setup_rhsm_api_mocks(
+        requests_mocker,
+        ["ami-fake-id-01-rhsm-failure"],
+    )
+
+    # override mocker for rhsm for PUT req.
+    requests_mocker.register_uri("PUT", re.compile("amazon/amis"), status_code=500)
+
+    cmd_args = [
+        "test-delete",
+        "--rhsm-url",
+        "https://rhsm.example.com",
+        "fake:",
+        "--aws-access-id",
+        "access_id",
+        "--aws-secret-key",
+        "secret_key",
+        "--debug",
+        "--aws-provider-name",
+        "awstest",
+    ]
+
+    command_tester.test(lambda: entry_point(AmiDelete), cmd_args)
+
+    mock_aws_delete.assert_not_called()
+    # check stored push items and images.json file content
+    stored_push_items = fake_collector.items
+
+    assert len(stored_push_items) == 0
+    assert fake_collector.file_content.get("images.json") is None
+
+
+def test_ami_delete_limit(
+    command_tester, requests_mocker, mock_aws_delete, fake_collector
+):
+    """
+    Tests a variant when no push item is left for processing
+    when --limit args is used.
+    """
+
+    fake_items = [
+        AmiPushItem(
+            name="fake-name-01",
+            image_id="ami-fake-id-01",
+            description="fake-descr-01",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+        AmiPushItem(
+            name="fake-name-02",
+            image_id="ami-fake-id-02",
+            description="fake-descr-01",
+            type="fake-type",
+            region="awstest",
+            dest=["fake-dest"],
+            virtualization="fake-virt",
+            volume="fake-volume",
+            billing_codes=AmiBillingCodes(name="fake-bc", codes=["0", "1"]),
+            release=AmiRelease(
+                product="fake-product", date="20230306", arch="fake-arch", respin=1
+            ),
+        ),
+    ]
+    Source.register_backend("fake", lambda: fake_items)
+
+    _setup_rhsm_api_mocks(
+        requests_mocker,
+        ["ami-fake-id-01", "ami-fake-id-02"],
+    )
+
+    command_tester.test(
+        lambda: entry_point(AmiDelete),
+        [
+            "test-delete",
+            "--rhsm-url",
+            "https://example.com",
+            "fake:",
+            "--aws-access-id",
+            "access_id",
+            "--aws-secret-key",
+            "secret_key",
+            "--debug",
+            "--aws-provider-name",
+            "awstest",
+            "--limit",
+            "ami-id-wanted",
+        ],
+    )
+
+    mock_aws_delete.assert_not_called()
+
+    stored_push_items = fake_collector.items
+
+    assert len(stored_push_items) == 0
+    assert fake_collector.file_content.get("images.json") is None

--- a/tests/shared/test_task_interface.py
+++ b/tests/shared/test_task_interface.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 
-@pytest.fixture(params=["pubtools._ami.tasks.push"])
+@pytest.fixture(params=["pubtools._ami.tasks.push", "pubtools._ami.tasks.delete"])
 def task_module(request):
     __import__(request.param)
     return sys.modules[request.param]


### PR DESCRIPTION
This commit introduces pubtools-ami-delete command that
enables removal of AMI images and snapshot from AWS + it
does related update in RHSM metadata services (makes image
invisible). Deletion in AWS is done via cloudimg library
that communicates directly with AWS APIs.

There was rather large refactoring done, most notably:
1) Created `AmiBase` class and moved there common logic
   and args for both `push` and `delete` commands.
2) Moved exception classes to their own file exceptions.py.
3) Added saving/updating push items via Collector
4) Added usage of `step` decorator.