### PR TITLE
Fix CI failure installing rpm-py-installer

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e static
   coverage:
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e cov
       - name: Install pytest cov
@@ -55,7 +55,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e docs
   bandit-exitzero:
@@ -71,7 +71,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e bandit-exitzero
   bandit:
@@ -87,6 +87,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e bandit


### PR DESCRIPTION
This became broken by the release of pip 23.1 and virtualenv 20.21.1. Details on bug report:
junaruga/rpm-py-installer#276

Until there is a proper resolution, pin to an older virtualenv to avoid the issue.

Since the relevant deps here are used during installation of tox itself, the pinning unfortunately cannot be done using the requirements files consumed from *within* tox.