### PR TITLE
Fix publish-docs CI for rpm-py-installer

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e docs
       - name: Publish


### PR DESCRIPTION
Limit version of virtualenv due to:
https://github.com/junaruga/rpm-py-installer/issues/276