### PR TITLE
Fix boot_mode value in images.json [RHELDST-20472]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -105,7 +105,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/pubtools/_ami/rhsm.py
+++ b/pubtools/_ami/rhsm.py
@@ -1,12 +1,13 @@
-import threading
-import os
 import logging
+import os
+import threading
 from datetime import datetime
 from urllib.parse import urljoin
 
 import requests
 from more_executors import Executors
 from more_executors.futures import f_map
+
 
 LOG = logging.getLogger("pubtools.ami")
 

--- a/pubtools/_ami/services/aws.py
+++ b/pubtools/_ami/services/aws.py
@@ -1,9 +1,12 @@
 import logging
 import threading
 from functools import partial
+
 from cloudimg.aws import AWSService
-from pubtools._ami.arguments import from_environ
+
+from ..arguments import from_environ
 from .base import Service
+
 
 LOG = logging.getLogger("pubtools.ami")
 

--- a/pubtools/_ami/services/rhsm_.py
+++ b/pubtools/_ami/services/rhsm_.py
@@ -2,9 +2,11 @@ import logging
 import threading
 
 from pubtools.pluggy import pm
-from pubtools._ami.rhsm import RHSMClient
-from pubtools._ami.arguments import from_environ
+
+from ..arguments import from_environ
+from ..rhsm import RHSMClient
 from .base import Service
+
 
 LOG = logging.getLogger("pubtools.ami")
 

--- a/pubtools/_ami/tasks/base.py
+++ b/pubtools/_ami/tasks/base.py
@@ -1,16 +1,15 @@
-import logging
-import sys
-
 import datetime
 import json
-import attr
-
+import logging
+import sys
 from concurrent.futures import wait
 
+import attr
 from pushsource import Source, AmiPushItem, BootMode
-from pubtools._ami.task import AmiTask
-from pubtools._ami.arguments import SplitAndExtend
+
+from ..arguments import SplitAndExtend
 from ..services import RHSMClientService, AWSPublishService, CollectorService
+from ..task import AmiTask
 from .exceptions import MissingProductError
 
 

--- a/pubtools/_ami/tasks/base.py
+++ b/pubtools/_ami/tasks/base.py
@@ -7,7 +7,7 @@ import attr
 
 from concurrent.futures import wait
 
-from pushsource import Source, AmiPushItem
+from pushsource import Source, AmiPushItem, BootMode
 from pubtools._ami.task import AmiTask
 from pubtools._ami.arguments import SplitAndExtend
 from ..services import RHSMClientService, AWSPublishService, CollectorService
@@ -114,6 +114,8 @@ class AmiBase(AmiTask, RHSMClientService, AWSPublishService, CollectorService):
         def convert(obj):
             if isinstance(obj, (datetime.datetime, datetime.date)):
                 return obj.strftime("%Y%m%d")
+            if isinstance(obj, BootMode):
+                return obj.value
 
         mod_result = []
         push_items = []

--- a/pubtools/_ami/tasks/delete.py
+++ b/pubtools/_ami/tasks/delete.py
@@ -6,12 +6,12 @@ import attr
 from cloudimg.aws import AWSDeleteMetadata
 from more_executors import Executors, ExceptionRetryPolicy
 
-from pubtools._ami.arguments import SplitAndExtend
-
+from ..arguments import SplitAndExtend
 from ..services import AWSPublishService, CollectorService, RHSMClientService
+from ..task import AmiTask
 from .base import AmiBase
 from .exceptions import AWSDeleteError
-from pubtools._ami.task import AmiTask
+
 
 LOG = logging.getLogger("pubtools.ami")
 

--- a/pubtools/_ami/tasks/push.py
+++ b/pubtools/_ami/tasks/push.py
@@ -1,16 +1,16 @@
+import json
 import logging
 import os
-import json
 import attr
-
-from requests import HTTPError
-from more_executors import Executors, ExceptionRetryPolicy
 from cloudimg.aws import AWSPublishingMetadata
-from pubtools._ami.task import AmiTask
+from more_executors import Executors, ExceptionRetryPolicy
+from requests import HTTPError
 
 from ..services import RHSMClientService, AWSPublishService, CollectorService
+from ..task import AmiTask
 from .base import AmiBase
 from .exceptions import AWSPublishError
+
 
 LOG = logging.getLogger("pubtools.ami")
 

--- a/tests/logs/push/test_ami_push/test_aws_publish_failure_retry.txt
+++ b/tests/logs/push/test_ami_push/test_aws_publish_failure_retry.txt
@@ -5,13 +5,13 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [   ERROR] Upload image to AWS: failed
 [ WARNING] Upload failed
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [    INFO] Registering image ami-1234567 with rhsm
 [   DEBUG] Searching for product RHEL_HOURLY for provider awstest in rhsm
@@ -26,7 +26,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [    INFO] Registering image ami-1234567 with rhsm
 [   DEBUG] Searching for product RHEL_HOURLY for provider awstest in rhsm

--- a/tests/logs/push/test_ami_push/test_create_image_failure.txt
+++ b/tests/logs/push/test_ami_push/test_create_image_failure.txt
@@ -5,7 +5,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [    INFO] Registering image ami-1234567 with rhsm
 [   DEBUG] Searching for product RHEL_HOURLY for provider awstest in rhsm
@@ -23,7 +23,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [    INFO] Registering image ami-1234567 with rhsm
 [   DEBUG] Searching for product RHEL_HOURLY for provider awstest in rhsm

--- a/tests/logs/push/test_ami_push/test_create_region_failure.txt
+++ b/tests/logs/push/test_ami_push/test_create_region_failure.txt
@@ -5,7 +5,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [   ERROR] Failed creating region region-1 for image ami-1234567
 [    INFO] Update RHSM metadata: started
@@ -15,7 +15,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [   ERROR] Failed creating region region-1 for image ami-1234567
 [    INFO] Update RHSM metadata: started
@@ -25,7 +25,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [   ERROR] Failed creating region region-1 for image ami-1234567
 [    INFO] Update RHSM metadata: started
@@ -35,7 +35,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [   ERROR] Failed creating region region-1 for image ami-1234567
 [    INFO] Update RHSM metadata: started

--- a/tests/logs/push/test_ami_push/test_do_push.txt
+++ b/tests/logs/push/test_ami_push/test_do_push.txt
@@ -5,7 +5,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-r"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-r"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [    INFO] Registering image ami-1234567 with rhsm
 [   DEBUG] Searching for product RHEL_HOURLY for provider awstest in rhsm

--- a/tests/logs/push/test_ami_push/test_no_aws_credentials.txt
+++ b/tests/logs/push/test_ami_push/test_no_aws_credentials.txt
@@ -5,7 +5,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: False)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [   ERROR] Upload image to AWS: failed
 [ WARNING] Upload failed
 [   ERROR] AMI upload failed:

--- a/tests/logs/push/test_ami_push/test_push_public_image.txt
+++ b/tests/logs/push/test_ami_push/test_push_public_image.txt
@@ -5,7 +5,7 @@
 [    INFO] Upload image to AWS: started
 [    INFO] Uploading /tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw to region region-1 (type: hourly, ship: True)
 [    INFO] Image name: RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2
-[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": null, "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
+[   DEBUG] {"accounts": ["secret-1"], "arch": "x86_64", "billing_products": ["code-0001"], "boot_mode": "hybrid", "container": "redhat-cloudimg-region-1", "description": "Provided by Red Hat, Inc.", "ena_support": true, "image_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "image_path": "/tmp/aws_staged/region-1-hourly/AWS_IMAGES/ami-1.raw", "root_device_name": "/dev/sda1", "snapshot_account_ids": ["0987654321", "1234567890", "684062674729"], "snapshot_name": "RHEL-8.5-RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2", "sriov_net_support": "simple", "virt_type": "hvm", "volume_type": "gp2"}
 [    INFO] Creating region region-1 [awstest]
 [    INFO] Registering image ami-1234567 with rhsm
 [   DEBUG] Searching for product RHEL_HOURLY for provider awstest in rhsm

--- a/tests/push/data/aws_staged/pub-mapfile.json
+++ b/tests/push/data/aws_staged/pub-mapfile.json
@@ -35,5 +35,6 @@
           }, 
           "relative_path": "region-1-hourly/AWS_IMAGES/ami-1.raw"
         }
-      ]}
-} 
+      ]
+    }
+}

--- a/tests/push/data/aws_staged/pub-mapfile.json
+++ b/tests/push/data/aws_staged/pub-mapfile.json
@@ -12,7 +12,7 @@
               ], 
               "name": "Hourly2"
             },
-            "boot_mode": null,
+            "boot_mode": "hybrid",
             "description": "Provided by Red Hat, Inc.",
             "ena_support": true, 
             "region": "region-1", 

--- a/tests/push/test_ami_delete.py
+++ b/tests/push/test_ami_delete.py
@@ -1,7 +1,7 @@
 import json
 import re
-
 import pytest
+
 from mock import patch
 from pushsource import AmiBillingCodes, AmiPushItem, AmiRelease, Source
 

--- a/tests/push/test_ami_push.py
+++ b/tests/push/test_ami_push.py
@@ -1,17 +1,20 @@
+import json
 import os
 import re
 import shutil
-import pytest
-import json
-import yaml
-from logging import DEBUG
 from collections import OrderedDict
-from mock import patch, MagicMock
-from pubtools._ami.tasks.push import AmiPush, entry_point, LOG
 from enum import Enum
+from logging import DEBUG
+
+import pytest
+import yaml
+from cloudimg.aws import AWSBootMode
+from mock import patch, MagicMock
 from pushsource import AmiPushItem
 from requests import HTTPError
-from cloudimg.aws import AWSBootMode
+
+from pubtools._ami.tasks.push import AmiPush, entry_point, LOG
+
 
 AMI_STAGE_ROOT = "/tmp/aws_staged"  # nosec B108
 AMI_SOURCE = "staged:%s" % AMI_STAGE_ROOT
@@ -21,11 +24,10 @@ def compare_metadata(metadata, exp_metadata):
     """
     Helper fction to compare metadata object with a dictionary of expected metadata
     """
-    result = True
     for key, value in exp_metadata.items():
         if getattr(metadata, key) != value:
-            result = False
-    return result
+            return False
+    return True
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/push/test_ami_push.py
+++ b/tests/push/test_ami_push.py
@@ -11,6 +11,7 @@ from pubtools._ami.tasks.push import AmiPush, entry_point, LOG
 from enum import Enum
 from pushsource import AmiPushItem
 from requests import HTTPError
+from cloudimg.aws import AWSBootMode
 
 AMI_STAGE_ROOT = "/tmp/aws_staged"  # nosec B108
 AMI_SOURCE = "staged:%s" % AMI_STAGE_ROOT
@@ -101,7 +102,7 @@ def mock_region_data():
         first_ami_data = {
             "name": "ami-01",
             "billing_codes": {"codes": ["code-0001"], "name": "Hourly2"},
-            "boot_mode": None,
+            "boot_mode": "hybrid",
             "description": "Provided by Red Hat, Inc.",
             "ena_support": True,
             "region": "region-1",
@@ -222,6 +223,7 @@ def test_do_push(command_tester, requests_mocker, mock_aws_publish, fake_collect
         "accounts": ["secret-r"],
         "groups": [],
         "tags": None,
+        "boot_mode": AWSBootMode.hybrid,
     }
     aws_publish_args, _ = mock_aws_publish.call_args_list[0]
     aws_metadata = aws_publish_args[0]
@@ -236,6 +238,7 @@ def test_do_push(command_tester, requests_mocker, mock_aws_publish, fake_collect
     images_json = json.loads(fake_collector.file_content["images.json"])
     assert len(images_json) == 1
     assert "ami-1234567" == images_json[0]["ami"]
+    assert "hybrid" == images_json[0]["boot_mode"]
 
 
 def test_no_source(command_tester, capsys):
@@ -354,6 +357,7 @@ def test_push_public_image(
         "accounts": ["secret-1"],
         "groups": ["all"],
         "tags": None,
+        "boot_mode": AWSBootMode.hybrid,
     }
     aws_publish_args, _ = mock_aws_publish.call_args_list[0]
     aws_metadata = aws_publish_args[0]
@@ -519,6 +523,7 @@ def test_aws_publish_failure_retry(
         "accounts": ["secret-1"],
         "groups": [],
         "tags": None,
+        "boot_mode": AWSBootMode.hybrid,
     }
     aws_publish_args, _ = mock_aws_publish.call_args_list[0]
     aws_metadata = aws_publish_args[0]

--- a/tests/rhsm/test_rhsm_client.py
+++ b/tests/rhsm/test_rhsm_client.py
@@ -1,6 +1,7 @@
 import logging
 from mock import patch
 from requests.exceptions import ConnectionError
+
 from pubtools._ami.rhsm import RHSMClient
 
 

--- a/tests/shared/test_ami_task.py
+++ b/tests/shared/test_ami_task.py
@@ -3,6 +3,7 @@ from mock import patch
 
 from pubtools._ami.task import AmiTask
 
+
 step = AmiTask.step
 
 


### PR DESCRIPTION
Previously, the boot_mode value in the images.json file was populated incorrectly, resulting in false null values or no boot_mode at all.  This commit fixes the logic so that the correct value is populated.

This PR also fixes some minor nitpicks

-  sort imports
-  convert absolute imports to relative
-  optimize `compare_metadata`
-  format json parentheses
-  fix sphinx warnings