### PR TITLE
[ci] fix install of OS packages in CI workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
+      - name: Install OS packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -7,8 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install RPM
+      - name: Install OS packages
         run: |
+          sudo apt-get -y update
           sudo apt-get install -y rpm
           sudo apt-get install -y libkrb5-dev
       - name: Setup Python
@@ -23,8 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install RPM
+      - name: Install OS packages
         run: |
+          sudo apt-get -y update
           sudo apt-get install -y rpm
           sudo apt-get install -y libkrb5-dev
       - name: Setup Python
@@ -46,8 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install RPM
+      - name: Install OS packages
         run: |
+          sudo apt-get -y update
           sudo apt-get install -y rpm
           sudo apt-get install -y libkrb5-dev
       - name: Setup Python
@@ -62,8 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install RPM
+      - name: Install OS packages
         run: |
+          sudo apt-get -y update
           sudo apt-get install -y rpm
           sudo apt-get install -y libkrb5-dev
       - name: Setup Python
@@ -78,8 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install RPM
+      - name: Install OS packages
         run: |
+          sudo apt-get -y update
           sudo apt-get install -y rpm
           sudo apt-get install -y libkrb5-dev
       - name: Setup Python


### PR DESCRIPTION
We should be using "apt-get update" to update package lists before installing any new packages. This has never mattered before, but recently the installation of various packages started to fail with 404 errors, which are resolved by updating the package lists first.