### PR TITLE
Update codecov-action to v4 for tokenless uploads from forked repos

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
codecov-action now requires token for upload. However, v4 supports tokeless uploads from PRs on forked repos. Hence, this add the token env var for codecov-action and updates the version to v4