### PR TITLE
Update black config for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.13


### PR DESCRIPTION
* bump to the latest version
* use py3.13 as py3.8 doesn't seem to be supported according to error in e.g. https://github.com/release-engineering/pubtools-ami/pull/199