### PR TITLE
Update codecov-action to v5 [RHELDST-40403]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -22,6 +22,8 @@ jobs:
         run: tox -e static
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Install OS packages
@@ -40,10 +42,12 @@ jobs:
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v5
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref =='refs/heads/main')
         with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.xml
           fail_ci_if_error: true
           verbose: true
   docs:


### PR DESCRIPTION
Updates codecov-action to v5, uses OIDC authentication, and adds the unit-tests flag to codecov reports. Only runs codecov-action on pull-requests and pushes to main